### PR TITLE
Blend modes to Pytorch/Float/Batches, Blur nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ from .colors import ColorBalance, ColorBalanceAdvanced
 from .colors import BlackAndWhite
 from .colors import HueSatAdvanced, HueSat
 from .colors import SolidColorRGB, SolidColorHSV, SolidColor
-from .blur import MotionBlur
+from .blur import MotionBlur, LensBlur, GaussianBlur
 
 NODE_CLASS_MAPPINGS = {
     "BlackAndWhite": BlackAndWhite,
@@ -18,7 +18,9 @@ NODE_CLASS_MAPPINGS = {
     "HueSat": HueSat,
     "HueSatAdvanced": HueSatAdvanced,
     "Levels": Levels,
-    "MotionBlur" :MotionBlur,
+    "LensBlur": LensBlur,
+    "MotionBlur": MotionBlur,
+    "GaussianBlur": GaussianBlur,
     "MergeRGB": MergeRGB,
     "SplitRGB": SplitRGB,
     "SelectiveColor": SelectiveColor,
@@ -36,7 +38,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "HueSat": "Hue/Saturation",
     "HueSatAdvanced": "Hue/Saturation Advanced",
     "Levels": "Levels",
+    "LensBlur": "Lens Blur",
     "MotionBlur":"Motion Blur",
+    "GaussianBlur": "Gaussian Blur",
     "MergeRGB": "Merge RGB",
     "SplitRGB": "Split RGB",
     "SelectiveColor": "Selective Color",

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ from .colors import ColorBalance, ColorBalanceAdvanced
 from .colors import BlackAndWhite
 from .colors import HueSatAdvanced, HueSat
 from .colors import SolidColorRGB, SolidColorHSV, SolidColor
-from .blur import MotionBlur, LensBlur, GaussianBlur
+from .blur import MotionBlur, LensBlur, GaussianBlur, MotionBlurDepth, LensBlurDepth, GaussianBlurDepth
 
 NODE_CLASS_MAPPINGS = {
     "BlackAndWhite": BlackAndWhite,
@@ -21,6 +21,9 @@ NODE_CLASS_MAPPINGS = {
     "LensBlur": LensBlur,
     "MotionBlur": MotionBlur,
     "GaussianBlur": GaussianBlur,
+    "LensBlurDepth": LensBlurDepth,
+    "MotionBlurDepth": MotionBlurDepth,
+    "GaussianBlurDepth": GaussianBlurDepth,
     "MergeRGB": MergeRGB,
     "SplitRGB": SplitRGB,
     "SelectiveColor": SelectiveColor,
@@ -41,6 +44,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "LensBlur": "Lens Blur",
     "MotionBlur":"Motion Blur",
     "GaussianBlur": "Gaussian Blur",
+    "LensBlurDepth": "Lens Blur with Depth Map",
+    "MotionBlurDepth":"Motion Blur with Depth Map",
+    "GaussianBlurDepth": "Gaussian Blur with Depth Map",
     "MergeRGB": "Merge RGB",
     "SplitRGB": "Split RGB",
     "SelectiveColor": "Selective Color",

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ from .colors import ColorBalance, ColorBalanceAdvanced
 from .colors import BlackAndWhite
 from .colors import HueSatAdvanced, HueSat
 from .colors import SolidColorRGB, SolidColorHSV, SolidColor
+from .blur import MotionBlur
 
 NODE_CLASS_MAPPINGS = {
     "BlackAndWhite": BlackAndWhite,
@@ -17,6 +18,7 @@ NODE_CLASS_MAPPINGS = {
     "HueSat": HueSat,
     "HueSatAdvanced": HueSatAdvanced,
     "Levels": Levels,
+    "MotionBlur" :MotionBlur,
     "MergeRGB": MergeRGB,
     "SplitRGB": SplitRGB,
     "SelectiveColor": SelectiveColor,
@@ -34,6 +36,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "HueSat": "Hue/Saturation",
     "HueSatAdvanced": "Hue/Saturation Advanced",
     "Levels": "Levels",
+    "MotionBlur":"Motion Blur",
     "MergeRGB": "Merge RGB",
     "SplitRGB": "Split RGB",
     "SelectiveColor": "Selective Color",

--- a/blur.py
+++ b/blur.py
@@ -118,33 +118,209 @@ class GaussianBlur:
 
     def do_blur(self, image, amount):
         return blur(image, "gaussian", amount=amount)
+    
+class MotionBlurDepth:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
+        
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "depth_map": ("IMAGE",),
+                "angle": ("INT", {
+                    "default": 0.0,
+                    "min": 0.0,
+                    "max": 360.0,
+                    "step": 0.1,
+                    "round": 0.01, 
+                    "display": "number"}),
+                "num_layers": ("INT", {
+                    "default": 10,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "min_blur": ("INT", {
+                    "default": 1,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "max_blur": ("INT", {
+                    "default": 100,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"})
+            }
+        }
 
-def blur(image, type, **kwargs):
-        
-        if image.shape[3] == 4:
-            original_alpha = image[:, :, :, 3]
-            image = image[:, :, :, :3]
-        else:
-            original_alpha = None
-        
-        blurred_images = []
-        for img in image:            
-            img_cv2 = img.cpu().numpy()
-            img_cv2 = (img_cv2 * 255).astype(np.uint8)  
-            img_cv2 = cv2.cvtColor(img_cv2, cv2.COLOR_RGB2BGR)
-            if type == "gaussian":
-                blurred_img_cv2 = gaussian_blur(img_cv2, kwargs["amount"])
-            elif type == "lens":
-                blurred_img_cv2 = lens_blur(img_cv2, kwargs["radius"], kwargs["components"], kwargs["exposure_gamma"])
-            elif type == "motion":
-                blurred_img_cv2 = motion_blur(img_cv2, kwargs["size"], kwargs["angle"])
-            blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
-            blurred_img = torch.from_numpy(blurred_img.astype(np.float32) / 255.0).to(image.device)  
-            blurred_images.append(blurred_img)
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
 
-        final_tensor = torch.stack(blurred_images)
+    def do_blur(self, image, depth_map, angle, num_layers, min_blur, max_blur):
+        return blur(image, "motion_depth", depth_map=depth_map, angle=angle, num_layers=num_layers, min_blur=min_blur, max_blur=max_blur)  
+
+class LensBlurDepth:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
         
-        if original_alpha is not None:
-            final_tensor = torch.cat((final_tensor, original_alpha.unsqueeze(3)), dim=3)
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "depth_map": ("IMAGE",),
+                "components": ("INT", {
+                    "default": 4,
+                    "min": 1,
+                    "max": 6,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "exposure_gamma": ("FLOAT", {
+                    "default": 2,
+                    "min": -100,
+                    "max": 100,
+                    "step": 0.01,
+                    "round": 0.01, 
+                    "display": "number"}),
+                "num_layers": ("INT", {
+                    "default": 10,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "min_blur": ("INT", {
+                    "default": 1,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "max_blur": ("INT", {
+                    "default": 100,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"})
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
+
+    def do_blur(self, image, depth_map, components, exposure_gamma, num_layers, min_blur, max_blur):
+        return blur(image, "lens_depth", depth_map=depth_map, components=components, exposure_gamma=exposure_gamma, num_layers=num_layers, min_blur=min_blur, max_blur=max_blur)
+
+class GaussianBlurDepth:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
         
-        return (final_tensor, )
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "depth_map": ("IMAGE",),
+                "sigma": ("INT", {
+                    "default": 5,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "num_layers": ("INT", {
+                    "default": 10,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "min_blur": ("INT", {
+                    "default": 1,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "max_blur": ("INT", {
+                    "default": 100,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"})
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
+
+    def do_blur(self, image, depth_map, sigma, num_layers, min_blur, max_blur):
+        return blur(image, "gaussian_depth",  depth_map=depth_map, sigma=sigma, num_layers=num_layers, min_blur=min_blur, max_blur=max_blur)
+
+
+def blur(image, type, depth_map=None, **kwargs):
+
+    if type in ["lens_depth", "gaussian_depth", "motion_depth"]:
+        if depth_map.shape[3] == 4:
+            depth_map = depth_map[:, :, :, :3]  # Remove alpha channel if it exists
+
+        # If batch size of depth_map does not match with image, use the first depth_map for all images
+        if depth_map.shape[0] != image.shape[0]:
+            depth_map = depth_map[0].unsqueeze(0).repeat(image.shape[0], 1, 1, 1)
+
+    if image.shape[3] == 4:
+        original_alpha = image[:, :, :, 3]
+        image = image[:, :, :, :3]
+    else:
+        original_alpha = None
+
+    blurred_images = []
+    for i, img in enumerate(image):
+        img_cv2 = img.cpu().numpy()
+        img_cv2 = (img_cv2 * 255).astype(np.uint8)
+        img_cv2 = cv2.cvtColor(img_cv2, cv2.COLOR_RGB2BGR)
+
+        if type == "gaussian":
+            blurred_img_cv2 = gaussian_blur(img_cv2, kwargs["amount"])
+        elif type == "lens":
+            blurred_img_cv2 = lens_blur(img_cv2, kwargs["radius"], kwargs["components"], kwargs["exposure_gamma"])
+        elif type == "motion":
+            blurred_img_cv2 = motion_blur(img_cv2, kwargs["size"], kwargs["angle"])
+        else: #depth map blur
+            depth_map_img = depth_map[i].cpu().numpy()
+            depth_map_img = (depth_map_img * 255).astype(np.uint8)
+            if type == "motion_depth":
+                blurred_img_cv2 = motion_blur_with_depth_map(img_cv2, depth_map=depth_map_img, angle=kwargs["angle"], num_layers=kwargs["num_layers"], min_blur=kwargs["min_blur"], max_blur=kwargs["max_blur"])
+            elif type == "lens_depth":
+                blurred_img_cv2 = lens_blur_with_depth_map(img_cv2, depth_map=depth_map_img, components=kwargs["components"], exposure_gamma=kwargs["exposure_gamma"], num_layers=kwargs["num_layers"], min_blur=kwargs["min_blur"], max_blur=kwargs["max_blur"])
+            elif type == "gaussian_depth":
+                blurred_img_cv2 = gaussian_blur_with_depth_map(img_cv2, depth_map=depth_map_img, sigma=kwargs["sigma"], num_layers=kwargs["num_layers"], min_blur=kwargs["min_blur"], max_blur=kwargs["max_blur"])
+        blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
+        blurred_img = torch.from_numpy(blurred_img.astype(np.float32) / 255.0).to(image.device)
+        blurred_images.append(blurred_img)
+
+    final_tensor = torch.stack(blurred_images)
+
+    if original_alpha is not None:
+        final_tensor = torch.cat((final_tensor, original_alpha.unsqueeze(3)), dim=3)
+
+    return (final_tensor, )

--- a/blur.py
+++ b/blur.py
@@ -106,9 +106,6 @@ class GaussianBlur:
                     "step": 1,
                     "round": 1, 
                     "display": "number"})
-            },
-            "optional": {
-                "depth_map": ("IMAGE",)
             }
         }
 

--- a/blur.py
+++ b/blur.py
@@ -1,0 +1,65 @@
+"""
+@author: Chris Freilich
+@title: Virtuoso Pack - Blur
+@nickname: Virtuoso Pack - Blur
+@description: This extension provides a blur nodes.
+"""
+import torch
+import cv2
+from blurgenerator import motion_blur
+
+class MotionBlur:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
+        
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "size": ("INT", {
+                    "default": 100.0,
+                    "min": 0.0,
+                    "max": 4096.0,
+                    "step": 0.1,
+                    "round": 0.01, 
+                    "display": "number"}),
+                "angle": ("INT", {
+                    "default": 0.0,
+                    "min": 0.0,
+                    "max": 360.0,
+                    "step": 0.1,
+                    "round": 0.01, 
+                    "display": "number"})
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
+
+    def do_blur(self, image, size, angle):
+        
+        if image.shape[3] == 4:
+            original_alpha = image[:, :, :, 3]
+            image = image[:, :, :, :3]
+        else:
+            original_alpha = None
+        
+        blurred_images = []
+        for img in image:            
+            img_cv2 = img.cpu().numpy()
+            img_cv2 = cv2.cvtColor(img_cv2, cv2.COLOR_RGB2BGR)
+            blurred_img_cv2 = motion_blur(img_cv2, size=size, angle=angle)
+            blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
+            blurred_img = torch.from_numpy(blurred_img).to(image.device)
+            blurred_images.append(blurred_img)
+
+        final_tensor = torch.stack(blurred_images)
+        
+        if original_alpha is not None:
+            final_tensor = torch.cat((final_tensor, original_alpha.unsqueeze(3)), dim=3)
+        
+        return (final_tensor, )

--- a/blur.py
+++ b/blur.py
@@ -2,11 +2,12 @@
 @author: Chris Freilich
 @title: Virtuoso Pack - Blur
 @nickname: Virtuoso Pack - Blur
-@description: This extension provides a blur nodes.
+@description: This extension provides blur nodes.
 """
 import torch
 import cv2
-from blurgenerator import motion_blur
+import numpy as np
+from blurgenerator import motion_blur, lens_blur, gaussian_blur
 
 class MotionBlur:
     
@@ -55,6 +56,122 @@ class MotionBlur:
             blurred_img_cv2 = motion_blur(img_cv2, size=size, angle=angle)
             blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
             blurred_img = torch.from_numpy(blurred_img).to(image.device)
+            blurred_images.append(blurred_img)
+
+        final_tensor = torch.stack(blurred_images)
+        
+        if original_alpha is not None:
+            final_tensor = torch.cat((final_tensor, original_alpha.unsqueeze(3)), dim=3)
+        
+        return (final_tensor, )
+    
+
+class LensBlur:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
+        
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "radius": ("INT", {
+                    "default": 5,
+                    "min": 1,
+                    "max": 4096,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "components": ("INT", {
+                    "default": 4,
+                    "min": 1,
+                    "max": 6,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"}),
+                "exposure_gamma": ("FLOAT", {
+                    "default": 2,
+                    "min": -100,
+                    "max": 100,
+                    "step": 0.01,
+                    "round": 0.01, 
+                    "display": "number"})
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
+
+    def do_blur(self, image, radius, components, exposure_gamma):
+        
+        if image.shape[3] == 4:
+            original_alpha = image[:, :, :, 3]
+            image = image[:, :, :, :3]
+        else:
+            original_alpha = None
+        
+        blurred_images = []
+        for img in image:            
+            img_cv2 = img.cpu().numpy()
+            img_cv2 = (img_cv2 * 255).astype(np.uint8)  # Convert to uint8
+            img_cv2 = cv2.cvtColor(img_cv2, cv2.COLOR_RGB2BGR)
+            blurred_img_cv2 = lens_blur(img_cv2, radius=radius, components=components, exposure_gamma=exposure_gamma)
+            blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
+            blurred_img = torch.from_numpy(blurred_img.astype(np.float32) / 255.0).to(image.device)  # Convert back to float32
+            blurred_images.append(blurred_img)
+
+        final_tensor = torch.stack(blurred_images)
+        
+        if original_alpha is not None:
+            final_tensor = torch.cat((final_tensor, original_alpha.unsqueeze(3)), dim=3)
+        
+        return (final_tensor, )
+
+
+class GaussianBlur:
+    
+    def __init__(self):
+        pass
+    
+    @classmethod
+    def INPUT_TYPES(s):
+        
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "amount": ("INT", {
+                    "default": 100,
+                    "min": 1,
+                    "max": 100,
+                    "step": 1,
+                    "round": 1, 
+                    "display": "number"})
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "do_blur"
+    CATEGORY = "Virtuoso/Blur"
+
+    def do_blur(self, image, amount):
+        
+        if image.shape[3] == 4:
+            original_alpha = image[:, :, :, 3]
+            image = image[:, :, :, :3]
+        else:
+            original_alpha = None
+        
+        blurred_images = []
+        for img in image:            
+            img_cv2 = img.cpu().numpy()
+            img_cv2 = (img_cv2 * 255).astype(np.uint8)  # Convert to uint8
+            img_cv2 = cv2.cvtColor(img_cv2, cv2.COLOR_RGB2BGR)
+            blurred_img_cv2 = gaussian_blur(img_cv2, amount)
+            blurred_img = cv2.cvtColor(blurred_img_cv2, cv2.COLOR_BGR2RGB)
+            blurred_img = torch.from_numpy(blurred_img.astype(np.float32) / 255.0).to(image.device)  # Convert back to float32
             blurred_images.append(blurred_img)
 
         final_tensor = torch.stack(blurred_images)

--- a/colors.py
+++ b/colors.py
@@ -783,7 +783,10 @@ def adjust_hue(hue, hue_offset):
     new_hue = (hue + hue_offset_normalized) % 1.0
     return new_hue
 
-def adjust_lightness(image_hsv, lightness_offset):
+def adjust_lightness(image, lightness_offset):
+    
+    image_hsv = image.clone()
+
     # Map lightness_offset to [-1, 1]
     offset = lightness_offset / 100.0
 

--- a/colors.py
+++ b/colors.py
@@ -669,7 +669,7 @@ class HueSat():
         base_hue = hues[hue]
         hue_low = base_hue - (widths[hue_width]/2)
         if hue_low < 0:
-            hue_low = 360 - hue_low
+            hue_low = 360 + hue_low
         hue_high = base_hue + (widths[hue_width]/2)
 
         mask = create_mask(image_hsv[..., 0], image_hsv[..., 1], hue_low, hue_high, feathers[feather]/2, feathers[feather]/2)

--- a/colors.py
+++ b/colors.py
@@ -13,7 +13,7 @@ from .hsv import rgb_to_hsv, hsv_to_rgb
 
 class SolidColorRGB():
     NAME = "Solid Color RGB"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Solid Color"
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ('solid color image',)
     FUNCTION = "get_solid_color"
@@ -76,7 +76,7 @@ class SolidColorRGB():
 
 class SolidColorHSV():
     NAME = "Solid Color HSV"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Solid Color"
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ('solid color image',)
     FUNCTION = "get_solid_color"
@@ -128,7 +128,7 @@ class SolidColorHSV():
 
 class SolidColor():
     NAME = "Solid Color"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Solid Color"
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ('solid color image',)
     FUNCTION = "get_solid_color"
@@ -196,7 +196,7 @@ class SplitRGB():
     RETURN_TYPES = ("IMAGE","IMAGE","IMAGE")
     RETURN_NAMES = ('red', 'green', 'blue',)
     FUNCTION = "do_split"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Channels"
     
     def do_split(self, image):
         # Create tensors for red, green, and blue channels
@@ -230,7 +230,7 @@ class MergeRGB():
 
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_merge"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Channels"
     
     def do_merge(self, red, green, blue):
        
@@ -247,7 +247,7 @@ class MergeRGB():
 
 class ColorBalance():
     NAME = "Color Balance"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_color_balance"
 
@@ -333,7 +333,7 @@ class ColorBalance():
 
 class ColorBalanceAdvanced():
     NAME = "Color Balance Advanced"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_color_balance"
 
@@ -419,7 +419,7 @@ def color_balance(img, shadows, midtones, highlights, shadow_center=0.15, midton
 
 class BlackAndWhite():
     NAME = "Black and White"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_black_and_white"
 
@@ -529,7 +529,7 @@ class BlackAndWhite():
 
 class HueSatAdvanced():
     NAME = "Hue/Saturation Advanced"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     RETURN_TYPES = ("IMAGE", "MASK")
     FUNCTION = "do_hue_sat"
 
@@ -621,7 +621,7 @@ class HueSatAdvanced():
 
 class HueSat():
     NAME = "Hue/Saturation"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     RETURN_TYPES = ("IMAGE", "MASK")
     FUNCTION = "do_hue_sat"
 

--- a/contrast.py
+++ b/contrast.py
@@ -6,7 +6,6 @@
 """
 import torch
 
-
 class Levels:
     
     def __init__(self):
@@ -59,7 +58,7 @@ class Levels:
 
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_levels"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
 
     def do_levels(self, image, channel, input_black_point, input_gamma, input_white_point, output_black_point, output_white_point):
         """

--- a/hsv.py
+++ b/hsv.py
@@ -1,0 +1,56 @@
+import torch
+
+def rgb_to_hsv(rgb):
+    # Separate the RGB channels
+    r, g, b = rgb[:, :, :, 0:1], rgb[:, :, :, 1:2], rgb[:, :, :, 2:3]
+
+    # Compute the HSV channels
+    max_val, _ = torch.max(rgb[:, :, :, :3], dim=-1, keepdim=True)
+    min_val, _ = torch.min(rgb[:, :, :, :3], dim=-1, keepdim=True)
+    diff = max_val - min_val
+
+    v = max_val
+
+    s = diff / v
+    s = torch.where(torch.isnan(s), torch.zeros_like(s), s)
+
+    h = torch.zeros_like(r)
+    h = torch.where((max_val == r) & (g >= b), ((g - b) / diff) / 6, h)
+    h = torch.where((max_val == r) & (g < b), ((g - b) / diff) / 6 + 1, h)
+    h = torch.where(max_val == g, ((b - r) / diff) / 6 + 1 / 3, h)
+    h = torch.where(max_val == b, ((r - g) / diff) / 6 + 2 / 3, h)
+    h = torch.where(max_val == min_val, torch.zeros_like(h), h)
+
+    # If the input has an alpha channel, append it to the output
+    if rgb.shape[-1] == 4:
+        hsv = torch.cat((h, s, v, rgb[:, :, :, 3:4]), dim=-1)
+    else:
+        hsv = torch.cat((h, s, v), dim=-1)
+
+    return hsv
+
+def hsv_to_rgb(hsv):
+    # Separate the HSV channels
+    h, s, v = hsv[:, :, :, 0:1], hsv[:, :, :, 1:2], hsv[:, :, :, 2:3]
+
+    # Compute the RGB channels
+    i = (h * 6).floor()
+    f = h * 6 - i
+    p = v * (1 - s)
+    q = v * (1 - f * s)
+    t = v * (1 - (1 - f) * s)
+
+    i = i % 6
+
+    r = torch.where(i == 0, v, torch.where(i == 1, q, torch.where(i == 2, p, torch.where(i == 3, p, torch.where(i == 4, t, v)))))
+    g = torch.where(i == 0, t, torch.where(i == 1, v, torch.where(i == 2, v, torch.where(i == 3, q, torch.where(i == 4, p, p)))))
+    b = torch.where(i == 0, p, torch.where(i == 1, p, torch.where(i == 2, t, torch.where(i == 3, v, torch.where(i == 4, v, q)))))
+
+    # If the input has an alpha channel, append it to the output
+    if hsv.shape[-1] == 4:
+        rgb = torch.cat((r, g, b, hsv[:, :, :, 3:4]), dim=-1)
+    else:
+        rgb = torch.cat((r, g, b), dim=-1)
+
+    return rgb
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ blend_modes
 Pillow
 torch
 scipy
+cv2
+blurgenerator

--- a/resize.py
+++ b/resize.py
@@ -13,21 +13,35 @@ def match_sizes(match_size, top, bottom, m=None):
             # Resize mask to match bottom_layer size
             mask = F.interpolate(m.unsqueeze(1), size=(bottom_layer.shape[1], bottom_layer.shape[2]), mode='nearest').squeeze(1).clone()
     else:
-        # Calculate scale factor for top_layer
-        scale_factor_top = max(bottom_layer.shape[1] / top_layer.shape[1], bottom_layer.shape[2] / top_layer.shape[2])
+        # Calculate the scale factors for both dimensions separately
+        scale_factor_h = bottom_layer.shape[1] / top_layer.shape[1]
+        scale_factor_w = bottom_layer.shape[2] / top_layer.shape[2]
+
+        # Use the correct scale factor to resize the top_layer
+        scale_factor = max(scale_factor_w, scale_factor_h) # must grow/shrink while covering both dimensions of bottom_layer
+
+        new_h = round(top_layer.shape[1] * scale_factor)
+        new_w = round(top_layer.shape[2] * scale_factor)
 
         # Resize top_layer while keeping aspect ratio constant
-        top_layer = F.interpolate(top_layer.permute(0, 3, 1, 2), scale_factor=scale_factor_top, mode='bilinear', align_corners=False).permute(0, 2, 3, 1)
+        top_layer = F.interpolate(top_layer.permute(0, 3, 1, 2), size=(new_h, new_w), mode='bilinear', align_corners=False).permute(0, 2, 3, 1)
 
         # Crop top_layer to match bottom_layer size
         top_layer = top_layer[:, :bottom_layer.shape[1], :bottom_layer.shape[2], :]
 
         if m is not None:
-            # Calculate scale factor for mask
-            scale_factor_mask = max(bottom_layer.shape[1] / m.shape[1], bottom_layer.shape[2] / m.shape[2])
+            # Calculate the scale factors for both dimensions separately for mask
+            scale_factor_mask_h = bottom_layer.shape[1] / m.shape[1]
+            scale_factor_mask_w = bottom_layer.shape[2] / m.shape[2]
+
+            # Use the correct scale factor to resize the mask
+            scale_factor_mask = max(scale_factor_mask_w, scale_factor_mask_h) # must grow to cover both dimensions
+
+            new_h_mask = round(m.shape[1] * scale_factor_mask)
+            new_w_mask = round(m.shape[2] * scale_factor_mask)
 
             # Resize and crop mask in the same way
-            mask = F.interpolate(m.unsqueeze(1), scale_factor=scale_factor_mask, mode='nearest').squeeze(1).clone()
+            mask = F.interpolate(m.unsqueeze(1), size=(new_h_mask, new_w_mask), mode='nearest').squeeze(1).clone()
             mask = mask[:, :bottom_layer.shape[1], :bottom_layer.shape[2]]
 
     return top_layer, mask

--- a/resize.py
+++ b/resize.py
@@ -1,0 +1,33 @@
+import torch.nn.functional as F
+
+def match_sizes(match_size, top, bottom, m=None):
+    top_layer = top.clone()
+    bottom_layer = bottom.clone()
+    mask = None
+
+    # Resize top_layer and mask to match bottom_layer
+    if match_size == 'stretch':
+        top_layer = F.interpolate(top_layer.permute(0, 3, 1, 2), size=(bottom_layer.shape[1], bottom_layer.shape[2]), mode='bilinear', align_corners=False).permute(0, 2, 3, 1)
+
+        if m is not None:
+            # Resize mask to match bottom_layer size
+            mask = F.interpolate(m.unsqueeze(1), size=(bottom_layer.shape[1], bottom_layer.shape[2]), mode='nearest').squeeze(1).clone()
+    else:
+        # Calculate scale factor for top_layer
+        scale_factor_top = max(bottom_layer.shape[1] / top_layer.shape[1], bottom_layer.shape[2] / top_layer.shape[2])
+
+        # Resize top_layer while keeping aspect ratio constant
+        top_layer = F.interpolate(top_layer.permute(0, 3, 1, 2), scale_factor=scale_factor_top, mode='bilinear', align_corners=False).permute(0, 2, 3, 1)
+
+        # Crop top_layer to match bottom_layer size
+        top_layer = top_layer[:, :bottom_layer.shape[1], :bottom_layer.shape[2], :]
+
+        if m is not None:
+            # Calculate scale factor for mask
+            scale_factor_mask = max(bottom_layer.shape[1] / m.shape[1], bottom_layer.shape[2] / m.shape[2])
+
+            # Resize and crop mask in the same way
+            mask = F.interpolate(m.unsqueeze(1), scale_factor=scale_factor_mask, mode='nearest').squeeze(1).clone()
+            mask = mask[:, :bottom_layer.shape[1], :bottom_layer.shape[2]]
+
+    return top_layer, mask

--- a/selectivecolor.py
+++ b/selectivecolor.py
@@ -56,7 +56,7 @@ class SelectiveColor:
 
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "do_selectivecolor"
-    CATEGORY = "Virtuoso"
+    CATEGORY = "Virtuoso/Adjustment"
     
     def do_selectivecolor(self, image, color_range, cyan, magenta, yellow, black, method):
         


### PR DESCRIPTION
All Blend Modes except the two grain modes now:

* Custom functions instead of blend-nodes package
* Support batches
* Better performance for HSV
* Removed Dodge mode, as it was the same as Color Dodge

6 New Blur Nodes
* Lens Blur / Lens Blur with Depth Map
* Motion Blur / Motion Blur with Depth Map
* Gaussian Blur / Gaussian Blur with Depth Map